### PR TITLE
fix: blog sidebar

### DIFF
--- a/src/components/molecules/BlogSideBar.tsx
+++ b/src/components/molecules/BlogSideBar.tsx
@@ -149,10 +149,11 @@ const BlogSideBar = ({
 
                   <Box>
                     <Heading
-                      fontFamily="Playfair Display"
-                      fontWeight="700"
+                      noOfLines={2}
+                      fontFamily="Manrope"
                       fontSize="16px"
                       ml="20px"
+                      textTransform="uppercase"
                       lineHeight="21px"
                     >
                       {post.postHeading}

--- a/src/data/blog.ts
+++ b/src/data/blog.ts
@@ -369,7 +369,7 @@ export const BLOGS = [
       {
         bg: "#FFF",
         postId: "669ddb38-969d-416d-a0c9-662eb338a777",
-        isTopPost: true,
+        isTopPost: false,
         postsImg: lsgSkyChef,
         coverImage: lsgSkyChef2,
         postsDate: `News and Events / ${formatDate(


### PR DESCRIPTION
- Removes the 10th blog post from top post
- Changes the font family for the top post for clarity
- Truncates longer texts to a maximum of two lines